### PR TITLE
Removed occasional prompt to not confuse inexperienced users.

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,7 @@ Flask-CouchDB.
 Tests:
 To run the tests:
   - `pip install nose`
-  - `$ nosetests`
+  - `nosetests`
 
 
 Currently maintained by Jeff Widman


### PR DESCRIPTION
Then again, I suggest adding the `.rst` extension to the README file and using code block directives to mark up commands (including the common prompt prefix).